### PR TITLE
EliteMobs 8.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ processResources {
 }
 
 group 'com.magmaguy'
-version '8.1.0-SNAPSHOT'
+version '8.1.1-SNAPSHOT'
 
 repositories {
     maven {

--- a/src/main/java/com/magmaguy/elitemobs/EventsRegistrer.java
+++ b/src/main/java/com/magmaguy/elitemobs/EventsRegistrer.java
@@ -102,7 +102,7 @@ public class EventsRegistrer {
         register(new FirstTimeSetup());
 
         register(new DungeonInstance.DungeonInstanceEvents());
-        register(new DungeonKillTargetObjective.DungeonKilLTargetObjectiveListener());
+        register(new DungeonKillTargetObjective.DungeonKillTargetObjectiveListener());
 
         register(new com.magmaguy.elitemobs.versionnotifier.VersionChecker.VersionCheckerEvents());
 

--- a/src/main/java/com/magmaguy/elitemobs/api/ElitePhaseSwitchEvent.java
+++ b/src/main/java/com/magmaguy/elitemobs/api/ElitePhaseSwitchEvent.java
@@ -1,0 +1,31 @@
+package com.magmaguy.elitemobs.api;
+
+import com.magmaguy.elitemobs.mobconstructor.custombosses.CustomBossEntity;
+import com.magmaguy.elitemobs.mobconstructor.custombosses.PhaseBossEntity;
+import lombok.Getter;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class ElitePhaseSwitchEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+
+    @Getter
+    private final CustomBossEntity customBossEntity;
+    @Getter
+    private final PhaseBossEntity phaseBossEntity;
+
+    public ElitePhaseSwitchEvent(CustomBossEntity customBossEntity, PhaseBossEntity phaseBossEntity) {
+        this.customBossEntity = customBossEntity;
+        this.phaseBossEntity = phaseBossEntity;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+}

--- a/src/main/java/com/magmaguy/elitemobs/commands/UserCommands.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/UserCommands.java
@@ -356,8 +356,11 @@ public class UserCommands {
                 .senderType(Player.class)
                 .handler(commandContext -> {
                     MatchInstance matchInstance = MatchInstance.getPlayerInstance(((Player) commandContext.getSender()));
-                    if (matchInstance != null)
+                    if (matchInstance != null) {
                         matchInstance.countdownMatch();
+                    }
+                    else
+                        commandContext.getSender().sendMessage("[EliteMobs] You are not queued for instanced content!");
                 }));
 
         // /em quit - this is for instanced content

--- a/src/main/java/com/magmaguy/elitemobs/config/QuestsConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/QuestsConfig.java
@@ -102,6 +102,10 @@ public class QuestsConfig {
     private static String lowRankDynamicQuestWarning;
     @Getter
     private static String questTurnInObjective;
+    @Getter
+    private static int horizontalCharacterLimitBedrockMenu;
+    @Getter
+    private static int itemEntryCharacterLimitBedrockMenu;
 
     private QuestsConfig() {
     }
@@ -163,6 +167,9 @@ public class QuestsConfig {
         lowRankDynamicQuestWarning = ConfigurationEngine.setString(file, fileConfiguration, "lowRankDynamicQuestWarning", "&8[EliteMobs] &cYou can't take these quests with your current guild rank! Increase your guild rank to accept these quests.", true);
 
         questTurnInObjective = ConfigurationEngine.setString(file, fileConfiguration, "questTurnInObjective", "&a2Talk to $npcName", true);
+
+        horizontalCharacterLimitBedrockMenu = ConfigurationEngine.setInt(fileConfiguration, "horizontalCharacterLimitBedrockMenu", 30);
+        itemEntryCharacterLimitBedrockMenu = ConfigurationEngine.setInt(fileConfiguration, "itemEntryCharacterLimitBedrockMenu", 300);
 
         ConfigurationEngine.fileSaverOnlyDefaults(fileConfiguration, file);
     }

--- a/src/main/java/com/magmaguy/elitemobs/config/custombosses/CustomBossesConfigFields.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/custombosses/CustomBossesConfigFields.java
@@ -196,6 +196,10 @@ public class CustomBossesConfigFields extends CustomConfigFields implements Cust
     private ConfigurationSection rawEliteScripts = null;
     @Getter
     private List<EliteScript> eliteScript = null;
+    @Getter
+    @Setter
+    private String song = null;
+
 
     /**
      * Creates a new default pre-made Custom Boss. The boss is further customized through a builder pattern.
@@ -339,6 +343,7 @@ public class CustomBossesConfigFields extends CustomConfigFields implements Cust
         rawEliteScripts = fileConfiguration.getConfigurationSection("eliteScript");
         if (rawEliteScripts != null) eliteScript = EliteScript.parseBossScripts(rawEliteScripts);
 
+        this.song = processString("song", song, null, false);
     }
 
     public boolean isCustomModelExists() {

--- a/src/main/java/com/magmaguy/elitemobs/config/customspawns/premade/NetherSpawn.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/customspawns/premade/NetherSpawn.java
@@ -1,0 +1,14 @@
+package com.magmaguy.elitemobs.config.customspawns.premade;
+
+import com.magmaguy.elitemobs.config.customspawns.CustomSpawnConfigFields;
+import org.bukkit.World;
+
+import java.util.List;
+
+public class NetherSpawn extends CustomSpawnConfigFields {
+    public NetherSpawn(){
+        super("nether_spawn", true);
+        setCanSpawnInLight(true);
+        setValidWorldEnvironments(List.of(World.Environment.NETHER));
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/customspawns/premade/NormalSurfaceSpawn.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/customspawns/premade/NormalSurfaceSpawn.java
@@ -12,6 +12,7 @@ public class NormalSurfaceSpawn extends CustomSpawnConfigFields {
         super("normal_surface_spawn",
                 true);
         setSurfaceSpawn(true);
+        setCanSpawnInLight(true);
         try {
             setValidWorldEnvironments(new ArrayList<>(Arrays.asList(World.Environment.NORMAL, World.Environment.CUSTOM)));
         } catch (NoSuchFieldError ex) {

--- a/src/main/java/com/magmaguy/elitemobs/config/customspawns/premade/OceanSpawn.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/customspawns/premade/OceanSpawn.java
@@ -1,0 +1,24 @@
+package com.magmaguy.elitemobs.config.customspawns.premade;
+
+import com.magmaguy.elitemobs.config.customspawns.CustomSpawnConfigFields;
+import org.bukkit.World;
+import org.bukkit.block.Biome;
+
+import java.util.List;
+
+public class OceanSpawn extends CustomSpawnConfigFields {
+    public OceanSpawn(){
+        super("ocean_spawn", true);
+        setValidWorldEnvironments(List.of(World.Environment.NORMAL, World.Environment.CUSTOM));
+        setValidBiomes(List.of(
+                Biome.OCEAN,
+                Biome.COLD_OCEAN,
+                Biome.DEEP_OCEAN,
+                Biome.FROZEN_OCEAN,
+                Biome.LUKEWARM_OCEAN,
+                Biome.DEEP_FROZEN_OCEAN,
+                Biome.DEEP_LUKEWARM_OCEAN,
+                Biome.DEEP_OCEAN));
+        setSurfaceSpawn(true);
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/customspawns/premade/TheEndSurfaceSpawn.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/customspawns/premade/TheEndSurfaceSpawn.java
@@ -1,0 +1,15 @@
+package com.magmaguy.elitemobs.config.customspawns.premade;
+
+import com.magmaguy.elitemobs.config.customspawns.CustomSpawnConfigFields;
+import org.bukkit.World;
+
+import java.util.List;
+
+public class TheEndSurfaceSpawn extends CustomSpawnConfigFields {
+    public TheEndSurfaceSpawn() {
+        super("the_end_surface_spawn", true);
+        setSurfaceSpawn(true);
+        setCanSpawnInLight(true);
+        setValidWorldEnvironments(List.of(World.Environment.THE_END));
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/powers/premade/EliteScriptPowerConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/powers/premade/EliteScriptPowerConfig.java
@@ -1,0 +1,9 @@
+package com.magmaguy.elitemobs.config.powers.premade;
+
+import com.magmaguy.elitemobs.config.powers.PowersConfigFields;
+
+public class EliteScriptPowerConfig extends PowersConfigFields {
+    public EliteScriptPowerConfig() {
+        super("elite_script", true, "script", null);
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/powers/premade/FrostWalkerConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/powers/premade/FrostWalkerConfig.java
@@ -1,0 +1,9 @@
+package com.magmaguy.elitemobs.config.powers.premade;
+
+import com.magmaguy.elitemobs.config.powers.PowersConfigFields;
+
+public class FrostWalkerConfig extends PowersConfigFields {
+    public FrostWalkerConfig() {
+        super("frost_walker", true, "Frost Walker", null);
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/instanced/dungeons/DungeonKillPercentageObjective.java
+++ b/src/main/java/com/magmaguy/elitemobs/instanced/dungeons/DungeonKillPercentageObjective.java
@@ -11,8 +11,8 @@ public class DungeonKillPercentageObjective extends DungeonObjective {
     private final int currentAmount = 0;
     private double percentage;
 
-    public DungeonKillPercentageObjective(String objectiveString) {
-        super(objectiveString);
+    public DungeonKillPercentageObjective(DungeonInstance dungeonInstance, String objectiveString) {
+        super(dungeonInstance, objectiveString);
         String[] strings = objectiveString.split(":");
         for (String seperatedByColon : strings) {
             String[] separatedByEquals = seperatedByColon.split("=");

--- a/src/main/java/com/magmaguy/elitemobs/instanced/dungeons/DungeonKillTargetObjective.java
+++ b/src/main/java/com/magmaguy/elitemobs/instanced/dungeons/DungeonKillTargetObjective.java
@@ -20,8 +20,8 @@ public class DungeonKillTargetObjective extends DungeonObjective {
     private int currentAmount = 0;
 
 
-    public DungeonKillTargetObjective(String objectiveString) {
-        super(objectiveString);
+    public DungeonKillTargetObjective(DungeonInstance dungeonInstance, String objectiveString) {
+        super(dungeonInstance, objectiveString);
         String[] strings = objectiveString.split(":");
         for (String seperatedByColon : strings) {
             String[] separatedByEquals = seperatedByColon.split("=");
@@ -37,6 +37,7 @@ public class DungeonKillTargetObjective extends DungeonObjective {
                 new WarningMessage("Invalid entry for objective string! " + objectiveString + " could not be parsed correctly.");
             }
         }
+        initializeObjective(dungeonInstance);
     }
 
     @Override
@@ -53,13 +54,16 @@ public class DungeonKillTargetObjective extends DungeonObjective {
         }
     }
 
-    public static class DungeonKilLTargetObjectiveListener implements Listener {
+    public static class DungeonKillTargetObjectiveListener implements Listener {
         @EventHandler
         public void onEliteDeath(EliteMobDeathEvent event) {
             if (!(event.getEliteEntity() instanceof InstancedBossEntity instancedBossEntity)) return;
-            for (DungeonKillTargetObjective dungeonKillTargetObjective : dungeonKillTargetObjectiveList)
-                if (instancedBossEntity.getCustomBossesConfigFields().getFilename().equals(dungeonKillTargetObjective.getBossFilename()))
+            for (DungeonKillTargetObjective dungeonKillTargetObjective : dungeonKillTargetObjectiveList) {
+                if (instancedBossEntity.getCustomBossesConfigFields().getFilename().equals(dungeonKillTargetObjective.getBossFilename()) ||
+                        instancedBossEntity.getPhaseBossEntity() != null &&
+                                instancedBossEntity.getPhaseBossEntity().getPhase1Config().getFilename().equals(dungeonKillTargetObjective.getBossFilename()))
                     dungeonKillTargetObjective.incrementKills();
+            }
         }
     }
 }

--- a/src/main/java/com/magmaguy/elitemobs/instanced/dungeons/DungeonObjective.java
+++ b/src/main/java/com/magmaguy/elitemobs/instanced/dungeons/DungeonObjective.java
@@ -8,20 +8,21 @@ public class DungeonObjective {
     protected boolean completed = false;
     @Getter
     protected DungeonInstance dungeonInstance;
+
     /*
     Valid configuration string formats:
     Kill target: filename=boss.yml:amount=X
     Kill percentage: clearpercentage=X.Y
      */
-    public DungeonObjective(String objectiveString) {
-
+    public DungeonObjective(DungeonInstance dungeonInstance, String objectiveString) {
+        this.dungeonInstance = dungeonInstance;
     }
 
-    public static DungeonObjective registerObjective(String objectiveString) {
+    public static DungeonObjective registerObjective(DungeonInstance dungeonInstance, String objectiveString) {
         if (objectiveString.toLowerCase().contains("filename")) {
-            return new DungeonKillTargetObjective(objectiveString);
+            return new DungeonKillTargetObjective(dungeonInstance, objectiveString);
         } else if (objectiveString.toLowerCase().contains("clearpercentage")) {
-            return new DungeonKillPercentageObjective(objectiveString);
+            return new DungeonKillPercentageObjective(dungeonInstance, objectiveString);
         }
         return null;
     }

--- a/src/main/java/com/magmaguy/elitemobs/items/customloottable/SpecialCustomLootEntry.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customloottable/SpecialCustomLootEntry.java
@@ -21,7 +21,7 @@ public class SpecialCustomLootEntry extends CustomLootEntry implements Serializa
         //todo: Integrate Special Loot in its entirety to this class to make it mesh with how the rest of the loot works
         for (String processedString : rawString.split(":")) {
             String[] strings = processedString.split("=");
-            if ("wave".equals(strings[0].toLowerCase())) {
+            if ("wave".equalsIgnoreCase(strings[0])) {
                 try {
                     super.setWave(Integer.parseInt(strings[1]));
                 } catch (Exception ex) {

--- a/src/main/java/com/magmaguy/elitemobs/menus/CustomShopMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/menus/CustomShopMenu.java
@@ -129,15 +129,15 @@ public class CustomShopMenu {
 
             double itemValue = ItemWorthCalculator.determineItemWorth(itemStack, player);
 
+            boolean inventoryHasFreeSlots = false;
+            for (ItemStack iteratedStack : player.getInventory().getStorageContents())
+                if (iteratedStack == null) {
+                    inventoryHasFreeSlots = true;
+                    break;
+                }
+
             //These slots are for buying items
             if (EliteMenu.isTopMenu(event)) {
-
-                boolean inventoryHasFreeSlots = false;
-                for (ItemStack iteratedStack : player.getInventory())
-                    if (iteratedStack == null) {
-                        inventoryHasFreeSlots = true;
-                        break;
-                    }
 
                 if (!inventoryHasFreeSlots) {
 

--- a/src/main/java/com/magmaguy/elitemobs/menus/EliteMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/menus/EliteMenu.java
@@ -1,10 +1,13 @@
 package com.magmaguy.elitemobs.menus;
 
 import org.bukkit.Material;
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -28,12 +31,15 @@ public class EliteMenu implements Listener {
         return !isTopMenu(event);
     }
 
-    public static void cancel(Inventory eliteInventory, Inventory playerInventory, List<Integer> inputSlots) {
-        for (int slot : inputSlots)
+    public static void cancel(HumanEntity player, Inventory eliteInventory, Inventory playerInventory, List<Integer> inputSlots) {
+        for (int slot : inputSlots) {
             if (eliteInventory.getItem(slot) != null) {
-                playerInventory.addItem(eliteInventory.getItem(slot));
-                eliteInventory.remove(eliteInventory.getItem(slot));
+                HashMap<Integer, ItemStack> leftOvers = playerInventory.addItem(eliteInventory.getItem(slot));
+                eliteInventory.clear(slot);
+                if (!leftOvers.isEmpty())
+                    leftOvers.values().forEach(itemStack -> player.getWorld().dropItem(player.getLocation(), itemStack));
             }
+        }
     }
 
 }

--- a/src/main/java/com/magmaguy/elitemobs/menus/EnhancementMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/menus/EnhancementMenu.java
@@ -5,6 +5,7 @@ import com.magmaguy.elitemobs.api.utils.EliteItemManager;
 import com.magmaguy.elitemobs.config.DefaultConfig;
 import com.magmaguy.elitemobs.config.ResourcePackDataConfig;
 import com.magmaguy.elitemobs.config.menus.premade.EnhancementMenuConfig;
+import com.magmaguy.elitemobs.config.menus.premade.ProceduralShopMenuConfig;
 import com.magmaguy.elitemobs.items.EliteItemLore;
 import com.magmaguy.elitemobs.items.ItemTagger;
 import com.magmaguy.elitemobs.utils.ItemStackGenerator;
@@ -138,6 +139,13 @@ public class EnhancementMenu extends EliteMenu {
             Inventory EnhancementInventory = event.getView().getTopInventory();
             Inventory playerInventory = event.getView().getBottomInventory();
 
+            boolean inventoryHasFreeSlots = false;
+            for (ItemStack iteratedStack : player.getInventory().getStorageContents())
+                if (iteratedStack == null) {
+                    inventoryHasFreeSlots = true;
+                    break;
+                }
+
             if (isBottomMenu(event)) {
 
                 //Item is upgrade orb
@@ -162,7 +170,13 @@ public class EnhancementMenu extends EliteMenu {
                             calculateOutput(EnhancementInventory);
                         }
 
+
             } else if (isTopMenu(event)) {
+
+                if (!inventoryHasFreeSlots) {
+                    player.sendMessage(ProceduralShopMenuConfig.messageFullInventory);
+                    player.closeInventory();
+                }
 
                 //return item to inventory
                 if (event.getSlot() == scrapItemInputSlot || event.getSlot() == eliteItemInputSlot) {
@@ -175,7 +189,6 @@ public class EnhancementMenu extends EliteMenu {
                 //cancel button
                 if (event.getSlot() == EnhancementMenuConfig.cancelSlot) {
                     player.closeInventory();
-                    EliteMenu.cancel(event.getView().getTopInventory(), event.getView().getBottomInventory(), Arrays.asList(eliteItemInputSlot, scrapItemInputSlot));
                     return;
                 }
 
@@ -196,7 +209,10 @@ public class EnhancementMenu extends EliteMenu {
 
         @EventHandler
         public void onClose(InventoryCloseEvent event) {
-            inventories.remove(event.getInventory());
+            if (inventories.contains(event.getInventory())) {
+                inventories.remove(event.getInventory());
+                EliteMenu.cancel(event.getPlayer(), event.getView().getTopInventory(), event.getView().getBottomInventory(), Arrays.asList(eliteItemInputSlot, scrapItemInputSlot));
+            }
         }
 
     }

--- a/src/main/java/com/magmaguy/elitemobs/menus/ProceduralShopMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/menus/ProceduralShopMenu.java
@@ -135,7 +135,6 @@ public class ProceduralShopMenu {
 
                     player.sendMessage(ProceduralShopMenuConfig.messageFullInventory);
                     player.closeInventory();
-                    menus.remove(player);
 
                 } else if (EconomyHandler.checkCurrency(player.getUniqueId()) >= itemValue) {
                     //player has enough money

--- a/src/main/java/com/magmaguy/elitemobs/menus/RefinerMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/menus/RefinerMenu.java
@@ -3,6 +3,7 @@ package com.magmaguy.elitemobs.menus;
 import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.config.DefaultConfig;
 import com.magmaguy.elitemobs.config.ResourcePackDataConfig;
+import com.magmaguy.elitemobs.config.menus.premade.ProceduralShopMenuConfig;
 import com.magmaguy.elitemobs.config.menus.premade.RefinerMenuConfig;
 import com.magmaguy.elitemobs.config.menus.premade.SellMenuConfig;
 import com.magmaguy.elitemobs.items.ItemTagger;
@@ -157,6 +158,13 @@ public class RefinerMenu extends EliteMenu {
             Inventory shopInventory = event.getView().getTopInventory();
             Inventory playerInventory = event.getView().getBottomInventory();
 
+            boolean inventoryHasFreeSlots = false;
+            for (ItemStack iteratedStack : player.getInventory().getStorageContents())
+                if (iteratedStack == null) {
+                    inventoryHasFreeSlots = true;
+                    break;
+                }
+
             if (EliteMenu.isBottomMenu(event)) {
                 //CASE: If the player clicked on something in their inventory to put it on the shop
 
@@ -182,6 +190,11 @@ public class RefinerMenu extends EliteMenu {
                 refreshOutputVisuals(shopInventory, RefinerMenuConfig.getOutputSlots(), player);
 
             } else if (EliteMenu.isTopMenu(event)) {
+                if (!inventoryHasFreeSlots) {
+                    player.sendMessage(ProceduralShopMenuConfig.messageFullInventory);
+                    player.closeInventory();
+                }
+
                 //CASE: Player clicked on the shop
 
                 //Signature item, does nothing
@@ -206,7 +219,6 @@ public class RefinerMenu extends EliteMenu {
                 //cancel, transfer items back to player inv and exit
                 if (event.getSlot() == SellMenuConfig.cancelSlot) {
                     player.closeInventory();
-                    EliteMenu.cancel(event.getView().getTopInventory(), event.getView().getBottomInventory(), inputSlots);
                     return;
                 }
 
@@ -224,7 +236,10 @@ public class RefinerMenu extends EliteMenu {
 
         @EventHandler
         public void onClose(InventoryCloseEvent event) {
-            inventories.remove(event.getInventory());
+            if (inventories.contains(event.getInventory())) {
+                inventories.remove(event.getInventory());
+                EliteMenu.cancel(event.getPlayer(), event.getView().getTopInventory(), event.getView().getBottomInventory(), inputSlots);
+            }
         }
 
     }

--- a/src/main/java/com/magmaguy/elitemobs/menus/RepairMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/menus/RepairMenu.java
@@ -4,6 +4,7 @@ import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.api.utils.EliteItemManager;
 import com.magmaguy.elitemobs.config.DefaultConfig;
 import com.magmaguy.elitemobs.config.ResourcePackDataConfig;
+import com.magmaguy.elitemobs.config.menus.premade.ProceduralShopMenuConfig;
 import com.magmaguy.elitemobs.config.menus.premade.RepairMenuConfig;
 import com.magmaguy.elitemobs.items.ItemTagger;
 import com.magmaguy.elitemobs.utils.ItemStackGenerator;
@@ -138,6 +139,14 @@ public class RepairMenu extends EliteMenu {
             Inventory repairInventory = event.getView().getTopInventory();
             Inventory playerInventory = event.getView().getBottomInventory();
 
+            boolean inventoryHasFreeSlots = false;
+            for (ItemStack iteratedStack : player.getInventory().getStorageContents())
+                if (iteratedStack == null) {
+                    inventoryHasFreeSlots = true;
+                    break;
+                }
+
+
             if (isBottomMenu(event)) {
                 //Item is scrap
                 if (ItemTagger.hasEnchantment(currentItem.getItemMeta(), "EliteScrap")) {
@@ -163,6 +172,11 @@ public class RepairMenu extends EliteMenu {
 
             } else if (isTopMenu(event)) {
 
+                if (!inventoryHasFreeSlots) {
+                    player.sendMessage(ProceduralShopMenuConfig.messageFullInventory);
+                    player.closeInventory();
+                }
+
                 //return item to inventory
                 if (event.getSlot() == scrapItemInputSlot || event.getSlot() == eliteItemInputSlot) {
                     playerInventory.addItem(currentItem);
@@ -174,7 +188,6 @@ public class RepairMenu extends EliteMenu {
                 //cancel button
                 if (event.getSlot() == RepairMenuConfig.cancelSlot) {
                     player.closeInventory();
-                    EliteMenu.cancel(event.getView().getTopInventory(), event.getView().getBottomInventory(), Arrays.asList(eliteItemInputSlot, scrapItemInputSlot));
                     return;
                 }
 
@@ -195,7 +208,10 @@ public class RepairMenu extends EliteMenu {
 
         @EventHandler
         public void onClose(InventoryCloseEvent event) {
-            inventories.remove(event.getInventory());
+            if (inventories.contains(event.getInventory())) {
+                inventories.remove(event.getInventory());
+                EliteMenu.cancel(event.getPlayer(), event.getView().getTopInventory(), event.getView().getBottomInventory(), Arrays.asList(eliteItemInputSlot, scrapItemInputSlot));
+            }
         }
 
     }

--- a/src/main/java/com/magmaguy/elitemobs/menus/ScrapperMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/menus/ScrapperMenu.java
@@ -7,6 +7,7 @@ import com.magmaguy.elitemobs.config.DefaultConfig;
 import com.magmaguy.elitemobs.config.ItemSettingsConfig;
 import com.magmaguy.elitemobs.config.ResourcePackDataConfig;
 import com.magmaguy.elitemobs.config.TranslationConfig;
+import com.magmaguy.elitemobs.config.menus.premade.ProceduralShopMenuConfig;
 import com.magmaguy.elitemobs.config.menus.premade.ScrapperMenuConfig;
 import com.magmaguy.elitemobs.config.menus.premade.SellMenuConfig;
 import com.magmaguy.elitemobs.items.customenchantments.SoulbindEnchantment;
@@ -110,6 +111,13 @@ public class ScrapperMenu extends EliteMenu {
             Inventory shopInventory = event.getView().getTopInventory();
             Inventory playerInventory = event.getView().getBottomInventory();
 
+            boolean inventoryHasFreeSlots = false;
+            for (ItemStack iteratedStack : player.getInventory().getStorageContents())
+                if (iteratedStack == null) {
+                    inventoryHasFreeSlots = true;
+                    break;
+                }
+
             if (EliteMenu.isBottomMenu(event)) {
                 //CASE: If the player clicked on something in their inventory to put it on the shop
 
@@ -134,6 +142,11 @@ public class ScrapperMenu extends EliteMenu {
                     }
 
             } else if (EliteMenu.isTopMenu(event)) {
+
+                if (!inventoryHasFreeSlots) {
+                    player.sendMessage(ProceduralShopMenuConfig.messageFullInventory);
+                    player.closeInventory();
+                }
                 //CASE: Player clicked on the shop
 
                 //Signature item, does nothing
@@ -170,7 +183,6 @@ public class ScrapperMenu extends EliteMenu {
                 //cancel, transfer items back to player inv and exit
                 if (event.getSlot() == SellMenuConfig.cancelSlot) {
                     player.closeInventory();
-                    EliteMenu.cancel(event.getView().getTopInventory(), event.getView().getBottomInventory(), validSlots);
                     return;
                 }
 
@@ -188,7 +200,10 @@ public class ScrapperMenu extends EliteMenu {
 
         @EventHandler
         public void onClose(InventoryCloseEvent event) {
-            inventories.remove(event.getInventory());
+            if (inventories.contains(event.getInventory())) {
+                inventories.remove(event.getInventory());
+                EliteMenu.cancel(event.getPlayer(), event.getView().getTopInventory(), event.getView().getBottomInventory(), validSlots);
+            }
         }
 
     }

--- a/src/main/java/com/magmaguy/elitemobs/menus/SellMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/menus/SellMenu.java
@@ -60,16 +60,6 @@ public class SellMenu extends EliteMenu implements Listener {
         return clonedConfirmButton;
     }
 
-    private static void cancel(Inventory playerInventory, Inventory shopInventory) {
-        for (Integer validSlot : validSlots) {
-            ItemStack itemStack = shopInventory.getItem(validSlot);
-            if (itemStack != null) {
-                playerInventory.addItem(itemStack);
-                shopInventory.remove(itemStack);
-            }
-        }
-    }
-
     /**
      * Creates a menu for selling elitemobs items. Only special Elite Mob items can be sold here.
      *
@@ -122,8 +112,6 @@ public class SellMenu extends EliteMenu implements Listener {
         }
 
         player.openInventory(sellInventory);
-        if (ResourcePackDataConfig.isDisplayCustomMenuUnicodes())
-            menuName = "\uF801\uDB80\uDC5B\uF805            " + menuName;
         createEliteMenu(sellInventory, inventories);
 
     }
@@ -216,9 +204,7 @@ public class SellMenu extends EliteMenu implements Listener {
 
             //cancel, transfer items back to player inv and exit
             if (event.getSlot() == SellMenuConfig.cancelSlot) {
-                cancel(playerInventory, shopInventory);
                 event.getWhoClicked().closeInventory();
-                cancel(event.getView().getBottomInventory(), event.getView().getTopInventory());
                 return;
             }
 
@@ -238,7 +224,10 @@ public class SellMenu extends EliteMenu implements Listener {
 
     @EventHandler
     public void onInventoryClose(InventoryCloseEvent event) {
-        inventories.remove(event.getInventory());
+        if (inventories.contains(event.getInventory())) {
+            inventories.remove(event.getInventory());
+            EliteMenu.cancel(event.getPlayer(), event.getView().getTopInventory(), event.getView().getBottomInventory(), SellMenuConfig.storeSlots);
+        }
     }
 
 }

--- a/src/main/java/com/magmaguy/elitemobs/menus/SmeltMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/menus/SmeltMenu.java
@@ -3,6 +3,7 @@ package com.magmaguy.elitemobs.menus;
 import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.config.DefaultConfig;
 import com.magmaguy.elitemobs.config.ResourcePackDataConfig;
+import com.magmaguy.elitemobs.config.menus.premade.ProceduralShopMenuConfig;
 import com.magmaguy.elitemobs.config.menus.premade.ScrapperMenuConfig;
 import com.magmaguy.elitemobs.config.menus.premade.SmeltMenuConfig;
 import com.magmaguy.elitemobs.items.ItemTagger;
@@ -149,6 +150,13 @@ public class SmeltMenu extends EliteMenu {
             Inventory smeltInventory = event.getView().getTopInventory();
             Inventory playerInventory = event.getView().getBottomInventory();
 
+            boolean inventoryHasFreeSlots = false;
+            for (ItemStack iteratedStack : player.getInventory().getStorageContents())
+                if (iteratedStack == null) {
+                    inventoryHasFreeSlots = true;
+                    break;
+                }
+
             if (isBottomMenu(event)) {
                 if (!ItemTagger.hasEnchantment(currentItem.getItemMeta(), "EliteScrap")) return;
                 boolean inputIsFull = true;
@@ -175,9 +183,13 @@ public class SmeltMenu extends EliteMenu {
 
             } else if (isTopMenu(event)) {
 
+                if (!inventoryHasFreeSlots) {
+                    player.sendMessage(ProceduralShopMenuConfig.messageFullInventory);
+                    player.closeInventory();
+                }
+
                 if (event.getSlot() == SmeltMenuConfig.cancelSlot) {
                     player.closeInventory();
-                    EliteMenu.cancel(event.getView().getTopInventory(), event.getView().getBottomInventory(), SmeltMenu.inputSlots);
                     return;
                 }
 
@@ -223,7 +235,10 @@ public class SmeltMenu extends EliteMenu {
 
         @EventHandler
         public void onInventoryCloseEvent(InventoryCloseEvent event) {
-            inventories.remove(event.getInventory());
+            if (inventories.contains(event.getInventory())) {
+                inventories.remove(event.getInventory());
+                EliteMenu.cancel(event.getPlayer(), event.getView().getTopInventory(), event.getView().getBottomInventory(), SmeltMenu.inputSlots);
+            }
         }
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/menus/UnbindMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/menus/UnbindMenu.java
@@ -4,6 +4,7 @@ import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.api.utils.EliteItemManager;
 import com.magmaguy.elitemobs.config.DefaultConfig;
 import com.magmaguy.elitemobs.config.ResourcePackDataConfig;
+import com.magmaguy.elitemobs.config.menus.premade.ProceduralShopMenuConfig;
 import com.magmaguy.elitemobs.config.menus.premade.UnbinderMenuConfig;
 import com.magmaguy.elitemobs.items.ItemTagger;
 import com.magmaguy.elitemobs.items.customenchantments.UnbindEnchantment;
@@ -127,6 +128,13 @@ public class UnbindMenu extends EliteMenu {
             Inventory unbinderInventory = event.getView().getTopInventory();
             Inventory playerInventory = event.getView().getBottomInventory();
 
+            boolean inventoryHasFreeSlots = false;
+            for (ItemStack iteratedStack : player.getInventory().getStorageContents())
+                if (iteratedStack == null) {
+                    inventoryHasFreeSlots = true;
+                    break;
+                }
+
             if (isBottomMenu(event)) {
                 //Item is unbind scroll
                 if (ItemTagger.hasEnchantment(currentItem.getItemMeta(), UnbindEnchantment.key)) {
@@ -149,6 +157,11 @@ public class UnbindMenu extends EliteMenu {
 
             } else if (isTopMenu(event)) {
 
+                if (!inventoryHasFreeSlots) {
+                    player.sendMessage(ProceduralShopMenuConfig.messageFullInventory);
+                    player.closeInventory();
+                }
+
                 //return item to inventory
                 if (event.getSlot() == scrapItemInputSlot || event.getSlot() == eliteItemInputSlot) {
                     playerInventory.addItem(currentItem);
@@ -160,7 +173,6 @@ public class UnbindMenu extends EliteMenu {
                 //cancel button
                 if (event.getSlot() == UnbinderMenuConfig.getCancelSlot()) {
                     player.closeInventory();
-                    EliteMenu.cancel(event.getView().getTopInventory(), event.getView().getBottomInventory(), Arrays.asList(eliteItemInputSlot, scrapItemInputSlot));
                     return;
                 }
 
@@ -181,7 +193,10 @@ public class UnbindMenu extends EliteMenu {
 
         @EventHandler
         public void onClose(InventoryCloseEvent event) {
-            inventories.remove(event.getInventory());
+            if (inventories.contains(event.getInventory())) {
+                inventories.remove(event.getInventory());
+                EliteMenu.cancel(event.getPlayer(), event.getView().getTopInventory(), event.getView().getBottomInventory(), Arrays.asList(eliteItemInputSlot, scrapItemInputSlot));
+            }
         }
 
     }

--- a/src/main/java/com/magmaguy/elitemobs/mobconstructor/custombosses/BossMusic.java
+++ b/src/main/java/com/magmaguy/elitemobs/mobconstructor/custombosses/BossMusic.java
@@ -1,0 +1,118 @@
+package com.magmaguy.elitemobs.mobconstructor.custombosses;
+
+import com.magmaguy.elitemobs.MetadataHandler;
+import com.magmaguy.elitemobs.utils.WarningMessage;
+import lombok.Getter;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class BossMusic {
+    private final HashMap<Player, BukkitTask> players = new HashMap<>();
+    @Getter
+    private String name;
+    @Getter
+    private int durationTicks;
+    @Getter
+    private String name2 = null;
+    @Getter
+    private int durationTicks2 = -1;
+    private BukkitTask bukkitTask = null;
+
+    //Format: name=rsp.name:length=durations_ms->name=rsp.name:length=duration_ms
+    public BossMusic(String rawString) {
+        if (!rawString.contains("->")) {
+            parse(rawString, 1);
+        } else {
+            String[] rawEntries = rawString.split("->");
+            parse(rawEntries[0], 1);
+            parse(rawEntries[1], 2);
+        }
+    }
+
+    private void parse(String rawString, int entryNumber) {
+        String[] strings = rawString.split(" ");
+        for (String string : strings) {
+            String[] parsed = string.split("=");
+            switch (parsed[0]) {
+                case "name":
+                    if (entryNumber == 1) name = parsed[1];
+                    else name2 = parsed[1];
+                    break;
+                case "length":
+                    if (entryNumber == 1) {
+                        durationTicks = (int) (Integer.parseInt(parsed[1]) / 1000D * 20D);
+                    } else {
+                        durationTicks2 = (int) (Integer.parseInt(parsed[1]) / 1000D * 20D);
+                    }
+                    break;
+                default:
+                    new WarningMessage("Failed to get value for boss music!");
+            }
+        }
+    }
+
+    public void start(CustomBossEntity customBossEntity) {
+        if (bukkitTask != null) {
+            bukkitTask.cancel();
+        }
+        bukkitTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!customBossEntity.isValid()) {
+                    stop();
+                    return;
+                }
+                play(customBossEntity.getLocation(), customBossEntity.getCustomBossesConfigFields().getFollowDistance());
+            }
+        }.runTaskTimer(MetadataHandler.PLUGIN, 0, 1);
+    }
+
+    public void stop() {
+        if (bukkitTask != null)
+            bukkitTask.cancel();
+        for (Map.Entry<Player, BukkitTask> entry : players.entrySet()) {
+            entry.getKey().stopSound(name);
+            entry.getValue().cancel();
+        }
+    }
+
+    private void play(Location location, double range) {
+        location.getWorld()
+                .getNearbyEntities(
+                        location,
+                        range,
+                        range,
+                        range,
+                        entity -> entity.getType().equals(EntityType.PLAYER))
+                .forEach(player -> {
+                    if (!players.containsKey((Player) player)) {
+                        ((Player) player).playSound(player.getLocation(), name, 1f, 1f);
+                        startLoopingTask((Player) player, durationTicks);
+                    }
+                });
+    }
+
+    private void startLoopingTask(Player player, int durationTicks) {
+        BukkitTask songTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (name2 != null)
+                    player.playSound(player.getLocation(), name2, 1f, 1f);
+                else
+                    player.playSound(player.getLocation(), name, 1f, 1f);
+                int duration;
+                if (durationTicks2 > 0) duration = durationTicks2;
+                else duration = durationTicks;
+                startLoopingTask(player, duration);
+            }
+        }.runTaskLater(MetadataHandler.PLUGIN, durationTicks);
+        players.put(player, songTask);
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/mobconstructor/custombosses/CustomBossEntity.java
+++ b/src/main/java/com/magmaguy/elitemobs/mobconstructor/custombosses/CustomBossEntity.java
@@ -57,6 +57,7 @@ public class CustomBossEntity extends EliteEntity implements Listener, Persisten
     protected LivingEntity livingEntityMount = null;
     protected CustomBossEntity mount;
     protected PersistentObjectHandler persistentObjectHandler = null;
+    @Setter
     protected Location persistentLocation;
     @Getter
     @Setter
@@ -89,6 +90,9 @@ public class CustomBossEntity extends EliteEntity implements Listener, Persisten
     private CustomModel customModel = null;
     @Getter
     private boolean normalizedCombat;
+    @Getter
+    @Setter
+    private BossMusic bossMusic = null;
 
     /**
      * Uses a builder pattern in order to construct a CustomBossEntity at an arbitrary point in the future. Does not
@@ -101,6 +105,7 @@ public class CustomBossEntity extends EliteEntity implements Listener, Persisten
     public CustomBossEntity(CustomBossesConfigFields customBossesConfigFields) {
         //This creates a placeholder empty EliteMobEntity to be filled in later
         super();
+        if (customBossesConfigFields.getSong() != null) bossMusic = new BossMusic(customBossesConfigFields.getSong());
         //This stores everything that will need to be initialized for the EliteMobEntity
         setCustomBossesConfigFields(customBossesConfigFields);
         super.setPersistent(customBossesConfigFields.isPersistent());
@@ -237,6 +242,8 @@ public class CustomBossEntity extends EliteEntity implements Listener, Persisten
 
         //It isn't worth initializing things that will notify players or spawn additional entities until we are certain that the boss has actually spawned
         if (livingEntity != null) {
+            if (bossMusic != null)
+                bossMusic.start(this);
             startBossTrails();
             mountEntity();
             //Prevent custom bosses from getting removed when far away, this is important for mounts and reinforcements in large arenas
@@ -417,6 +424,7 @@ public class CustomBossEntity extends EliteEntity implements Listener, Persisten
 
     @Override
     public void fullHeal() {
+        if (customBossesConfigFields.isInstanced()) return;
         if (phaseBossEntity == null || phaseBossEntity.isInFirstPhase()) {
             super.fullHeal();
             return;
@@ -489,6 +497,8 @@ public class CustomBossEntity extends EliteEntity implements Listener, Persisten
             //when bosses get removed due to chunk unloads and are persistent they should remain stored
             if (persistentObjectHandler != null)
                 persistentObjectHandler.updatePersistentLocation(getPersistentLocation());
+
+        if (!removalReason.equals(RemovalReason.PHASE_BOSS_PHASE_END) && bossMusic != null) bossMusic.stop();
     }
 
     @Override

--- a/src/main/java/com/magmaguy/elitemobs/powers/meta/ElitePower.java
+++ b/src/main/java/com/magmaguy/elitemobs/powers/meta/ElitePower.java
@@ -3,6 +3,7 @@ package com.magmaguy.elitemobs.powers.meta;
 import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.api.EliteMobDamagedByPlayerEvent;
 import com.magmaguy.elitemobs.api.PlayerDamagedByEliteMobEvent;
+import com.magmaguy.elitemobs.config.powers.PowersConfig;
 import com.magmaguy.elitemobs.config.powers.PowersConfigFields;
 import com.magmaguy.elitemobs.mobconstructor.EliteEntity;
 import com.magmaguy.elitemobs.utils.WarningMessage;
@@ -62,7 +63,7 @@ public class ElitePower {
         this.name = scriptName;
         this.powerCooldownTime = 0;//todo: update
         this.globalCooldownTime = 0;//todo: update
-        this.powersConfigFields = null; //todo: might want to actually give this a value when reading from the powers folder
+        this.powersConfigFields = PowersConfig.getPower("elite_script.yml"); //todo: this needs to get removed in the rewrite
     }
 
     //Costructor for classic powers

--- a/src/main/java/com/magmaguy/elitemobs/powers/miscellaneouspowers/FrostWalker.java
+++ b/src/main/java/com/magmaguy/elitemobs/powers/miscellaneouspowers/FrostWalker.java
@@ -1,0 +1,30 @@
+package com.magmaguy.elitemobs.powers.miscellaneouspowers;
+
+import com.magmaguy.elitemobs.MetadataHandler;
+import com.magmaguy.elitemobs.config.powers.PowersConfig;
+import com.magmaguy.elitemobs.powers.meta.MinorPower;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+
+public class FrostWalker extends MinorPower {
+
+    public FrostWalker() {
+        super(PowersConfig.getPower("frost_walker.yml"));
+    }
+
+    @Override
+    public void applyPowers(LivingEntity livingEntity) {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                ItemStack frostWalkerBoots = new ItemStack(Material.LEATHER_BOOTS);
+                frostWalkerBoots.addEnchantment(Enchantment.FROST_WALKER, 2);
+                livingEntity.getEquipment().setBoots(frostWalkerBoots);
+            }
+        }.runTaskLater(MetadataHandler.PLUGIN, 1);
+    }
+
+}

--- a/src/main/java/com/magmaguy/elitemobs/powers/scripts/EliteScript.java
+++ b/src/main/java/com/magmaguy/elitemobs/powers/scripts/EliteScript.java
@@ -11,13 +11,13 @@ import java.util.Collections;
 import java.util.List;
 
 public class EliteScript extends ElitePower {
-    private String scriptName;
+    private final String scriptName;
 
     //Parse from power file
-    private ScriptEvents scriptEvents;
-    private ScriptConditions scriptConditions;
-    private ScriptActions scriptActions;
-    private ScriptCooldowns scriptCooldowns;
+    private final ScriptEvents scriptEvents;
+    private final ScriptConditions scriptConditions;
+    private final ScriptActions scriptActions;
+    private final ScriptCooldowns scriptCooldowns;
     public EliteScript(ConfigurationSection configurationSection, String scriptName) {
         super(configurationSection, scriptName);
         this.scriptName = scriptName;
@@ -31,7 +31,6 @@ public class EliteScript extends ElitePower {
         }
         if (!scriptActions.isValid()) {
             new WarningMessage("Script does not have valid Actions for entry " + scriptName + "!");
-            return;
         }
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/powers/scripts/ScriptActions.java
+++ b/src/main/java/com/magmaguy/elitemobs/powers/scripts/ScriptActions.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -20,7 +21,7 @@ import java.util.stream.Collectors;
 
 public class ScriptActions {
     @Getter
-    private List<ScriptAction> scriptActions = new ArrayList();
+    private final List<ScriptAction> scriptActions = new ArrayList();
 
     public ScriptActions(List<Map<?, ?>> values, String scriptName) {
         for (Map<?, ?> entry : values)
@@ -46,7 +47,8 @@ public class ScriptActions {
         NEARBY_PLAYERS,
         WORLD_PLAYERS,
         ALL_PLAYERS,
-        PLAYER
+        PLAYER,
+        SELF
     }
 
     private class ScriptAction {
@@ -149,7 +151,7 @@ public class ScriptActions {
             }.runTaskLater(MetadataHandler.PLUGIN, wait);
         }
 
-        private Collection<? extends Player> getTargets(EliteEntity eliteEntity, Player player) {
+        private Collection<? extends LivingEntity> getTargets(EliteEntity eliteEntity, Player player) {
             Location eliteEntityLocation = eliteEntity.getLocation();
             return switch (target) {
                 case ALL_PLAYERS -> Bukkit.getOnlinePlayers();
@@ -157,6 +159,7 @@ public class ScriptActions {
                 case NEARBY_PLAYERS ->
                         eliteEntityLocation.getWorld().getNearbyEntities(eliteEntityLocation, range, range, range, (entity -> entity.getType() == EntityType.PLAYER)).stream().map(entity -> (Player) entity).collect(Collectors.toSet());
                 case PLAYER -> Collections.singletonList(player);
+                case SELF -> Collections.singletonList(eliteEntity.getLivingEntity());
                 default -> null;
             };
         }

--- a/src/main/java/com/magmaguy/elitemobs/powers/scripts/ScriptEvents.java
+++ b/src/main/java/com/magmaguy/elitemobs/powers/scripts/ScriptEvents.java
@@ -24,6 +24,7 @@ public class ScriptEvents {
                 case "EliteMobSpawnEvent" -> events.add(EliteMobSpawnEvent.class);
                 case "EliteMobTargetPlayerEvent" -> events.add(EliteMobTargetPlayerEvent.class);
                 case "PlayerDamagedByEliteMobEvent" -> events.add(PlayerDamagedByEliteMobEvent.class);
+                case "ElitePhaseSwitchEvent" -> events.add(ElitePhaseSwitchEvent.class);
                 default ->
                         new WarningMessage("Failed to get valid script event from entry " + entry + " in " + scriptName + " !");
             }

--- a/src/main/java/com/magmaguy/elitemobs/powers/scripts/ScriptListener.java
+++ b/src/main/java/com/magmaguy/elitemobs/powers/scripts/ScriptListener.java
@@ -59,6 +59,11 @@ public class ScriptListener implements Listener {
         runEvent(event, event.getEliteMobEntity(), event.getPlayer());
     }
 
+    @EventHandler
+    public void onElitePhaseSwitchEvent(ElitePhaseSwitchEvent event){
+        runEvent(event,event.getCustomBossEntity(), null);
+    }
+
     private void runEvent(Event event, EliteEntity eliteEntity, Player player) {
         for (ElitePower elitePower : eliteEntity.getElitePowers()) {
             if (elitePower instanceof EliteScript) {

--- a/src/main/java/com/magmaguy/elitemobs/quests/menus/QuestInventoryMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/quests/menus/QuestInventoryMenu.java
@@ -1,6 +1,7 @@
 package com.magmaguy.elitemobs.quests.menus;
 
 import com.magmaguy.elitemobs.commands.quests.QuestCommand;
+import com.magmaguy.elitemobs.config.QuestsConfig;
 import com.magmaguy.elitemobs.npcs.NPCEntity;
 import com.magmaguy.elitemobs.quests.CustomQuest;
 import com.magmaguy.elitemobs.quests.Quest;
@@ -114,7 +115,7 @@ public class QuestInventoryMenu {
         title = title.replace(ChatColor.BLACK.toString(), ChatColor.WHITE.toString());
         List<String> lore = new ArrayList<>();
         rawLore.forEach(raw -> lore.add(ChatColor.WHITE + raw.replace(ChatColor.BLACK.toString(), ChatColor.WHITE.toString())));
-        int characterLimit = 300;
+        int characterLimit = QuestsConfig.getItemEntryCharacterLimitBedrockMenu();
         List<ItemStack> itemStacks = new ArrayList<>();
         AtomicInteger counter = new AtomicInteger();
         lore.forEach(entry -> counter.addAndGet(entry.length()));
@@ -123,7 +124,7 @@ public class QuestInventoryMenu {
             return itemStacks;
         }
 
-        int maxCharactersPerLine = 30;
+        int maxCharactersPerLine = QuestsConfig.getHorizontalCharacterLimitBedrockMenu();
         List<String> currentList = new ArrayList<>();
         int currentCharacterCount = 0;
         for (String entry : lore) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: EliteMobs
-version: 8.1.0
+version: 8.1.1
 author: MagmaGuy
 main: com.magmaguy.elitemobs.EliteMobs
 api-version: 1.14


### PR DESCRIPTION
- [New] Added the song field to Custom Bosses, allowing admins to set custom music that will play to players near the boss. Phase bosses can be chained to ramp up the custom music. It is also possible to have songs with intros that transition into a loopable segment.
- [New] Added Frost Walker power
- [New] Added ElitePhaseSwitchEvent to the EliteMobs API
- [New] Added SELF as a valid Elite Script target, making the script able to target the boss for whom the event is happening
- [New] Added ElitePhaseSwitchEvent to the scriptable events
- [New] Added same_as_boss special world value for phase spawn locations of phase bosses, allowing bosses to use the same world as what they're currently in
- [New] Added the following default spawns for events: nether, end, ocean
- [New] Added horizontal and vertical character limit customization options for quest bedrock menus for admins experiencing issues with text going off-screen
- [Fix] Events using the normal surface spawn file should now be able to trigger during daytime as intended
- [Fix] Fixed issue where arenas would not work after the first run
- [Fix] Fixed issue where arenas would bug out if players left before the start countdown was over
- [Fix] Fixed a number of conditions in which players would get stuck in arenas and dungeons
- [Fix] Fixed issue where items would be lost when closing shop menus
- [Fix] Fixed issue where later stages of boss phases would not count towards instanced dungeon objectives
- [Fix] Fixed dungeon kill objectives not working

Signed-off-by: MagmaGuy <tiagoarnaut@gmail.com>